### PR TITLE
allow tabs to marked as uploadable [PLAT-34692]

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    docusign_templates (1.0.1)
+    docusign_templates (1.0.2)
       activesupport
       origami
 

--- a/lib/docusign_templates/pdf_writer.rb
+++ b/lib/docusign_templates/pdf_writer.rb
@@ -67,6 +67,7 @@ module DocusignTemplates
       recipients.each do |recipient|
         recipient.fields_for_document(document).each do |field|
           next if field.disabled?
+          next if field.uploadable?
 
           if field.is_radio_group?
             field.radios.each do |radio|

--- a/lib/docusign_templates/recipient.rb
+++ b/lib/docusign_templates/recipient.rb
@@ -46,6 +46,13 @@ module DocusignTemplates
         result[type] = enabled_tabs.map(&:as_composite_template_entry)
       end
 
+      fields.each do |type, type_fields|
+        uploadable_fields = type_fields.reject(&:disabled?).select(&:uploadable?)
+
+        next if uploadable_fields.empty?
+        result[type] = uploadable_fields.map(&:as_composite_template_entry)
+      end
+
       result
     end
 

--- a/lib/docusign_templates/version.rb
+++ b/lib/docusign_templates/version.rb
@@ -1,3 +1,3 @@
 module DocusignTemplates
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end

--- a/spec/pdf_writer_spec.rb
+++ b/spec/pdf_writer_spec.rb
@@ -210,6 +210,21 @@ module DocusignTemplates
         expect(yielded_fields).to eq([])
       end
 
+      it "does not yield uploadable fields" do
+        recipients.each do |recipient|
+          expect(recipient).to receive(:fields_for_document).with(document).and_return([
+            instance_double(Field, disabled?: false, uploadable?: true)
+          ])
+        end
+
+        yielded_fields = []
+        writer.send(:each_required_page_field, page_index) do |field|
+          yielded_fields << field
+        end
+
+        expect(yielded_fields).to eq([])
+      end
+
       context "radio group fields" do
         let(:radios) do
           [
@@ -221,7 +236,12 @@ module DocusignTemplates
         it "yields each radio for the page index" do
           recipients.each do |recipient|
             expect(recipient).to receive(:fields_for_document).with(document).and_return([
-              instance_double(Field, disabled?: false, is_radio_group?: true, radios: radios)
+              instance_double(Field, {
+                disabled?: false,
+                is_radio_group?: true,
+                uploadable?: false,
+                radios: radios
+              })
             ])
           end
 
@@ -241,8 +261,18 @@ module DocusignTemplates
         it "yields each field for the page index" do
           recipients.each do |recipient|
             expect(recipient).to receive(:fields_for_document).with(document).and_return([
-              instance_double(Field, disabled?: false, is_radio_group?: false, page_index: 0),
-              instance_double(Field, disabled?: false, is_radio_group?: false, page_index: page_index)
+              instance_double(Field, {
+                disabled?: false,
+                is_radio_group?: false,
+                page_index: 0,
+                uploadable?: false
+              }),
+              instance_double(Field, {
+                disabled?: false,
+                is_radio_group?: false,
+                page_index: page_index,
+                uploadable?: false
+              })
             ])
           end
 

--- a/spec/recipient_spec.rb
+++ b/spec/recipient_spec.rb
@@ -1,7 +1,7 @@
 module DocusignTemplates
   RSpec.describe Recipient do
     def make_tabs(type)
-      3.times.map do |index|
+      10.times.map do |index|
         {
           tab_type: type,
           tab_label: "#{type}.example.#{index}"
@@ -89,9 +89,21 @@ module DocusignTemplates
           tab.disabled = index.odd?
         end
 
+        recipient.fields.values.flatten.each_with_index do |tab, index|
+          tab.disabled = index.odd?
+          tab.uploadable = index % 3 == 0
+        end
+
         expected_tabs = {}.tap do |result|
           recipient.tabs.each do |type, type_tabs|
             result[type] = type_tabs.reject(&:disabled?).map(&:as_composite_template_entry)
+          end
+
+          recipient.fields.each do |type, type_fields|
+            result[type] = type_fields
+              .reject(&:disabled?)
+              .select(&:uploadable?)
+              .map(&:as_composite_template_entry)
           end
         end
 


### PR DESCRIPTION
- Allows PDF fields to be marked as uploadable so that they will upload as normal instead of writing to the PDF
- Ensures PDF fields are positioned correctly when uploaded instead of printed to the PDF
- This is working well for me locally