### PR TITLE
add support for multipart form uploads [PLAT-46743]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-git_source(:github) {|repo_name| "https://github.com/JonathanPierce/DocusignTemplates" }
+git_source(:github) {|repo_name| "https://github.com/BLC/DocusignTemplates" }
 
 # Specify your gem's dependencies in docusign_templates.gemspec
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    docusign_templates (1.0.2)
+    docusign_templates (2.0.0)
       activesupport
       origami
 
@@ -26,7 +26,7 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    rake (10.5.0)
+    rake (12.3.3)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -51,7 +51,7 @@ DEPENDENCIES
   bundler (~> 1.17)
   docusign_templates!
   pry
-  rake (~> 10.0)
+  rake (~> 12.3)
   rspec (~> 3.0)
 
 BUNDLED WITH

--- a/docusign_templates.gemspec
+++ b/docusign_templates.gemspec
@@ -41,6 +41,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "pry"
   spec.add_development_dependency "bundler", "~> 1.17"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 12.3"
   spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/lib/docusign_templates/document.rb
+++ b/lib/docusign_templates/document.rb
@@ -1,27 +1,48 @@
 module DocusignTemplates
   class Document
-    attr_reader :data, :base_directory
+    attr_reader :data, :base_directory, :document_id
+
+    MUTEX = Mutex.new
+
+    # Returns a thread-safe unique document ID, which overrides the one configured in the template.
+    # This is necessary because multipart form uplaods require each doc to have a unique ID.
+    def self.unique_document_id
+      MUTEX.synchronize do
+        @last_id ||= 1
+        value = @last_id
+        @last_id = [(@last_id + 1) % 1000, 1].max
+        value
+      end
+    end
 
     def initialize(data, base_directory)
       @data = data.deep_dup
       @base_directory = base_directory
+      @document_id = Document.unique_document_id
     end
 
     def merge!(other_data)
       data.merge!(other_data)
     end
 
-    def as_composite_template_entry(recipients)
-      data.except(:path).merge(
+    def as_composite_template_entry(recipients, options = {})
+      additional_data = options[:multipart] ? {
+        document_id: document_id
+      } : {
+        document_id: document_id,
         document_base64: Base64.encode64(to_pdf(recipients))
-      )
+      }
+
+      data.except(:path).merge(additional_data)
     end
 
     def path
       "#{base_directory}/#{data[:path]}"
     end
 
-    def document_id
+    # The original document_id from the template. This won't be used in `as_composite_template_entry`,
+    # but it used to match recipient tabs to this document.
+    def original_document_id
       data[:document_id]
     end
 

--- a/lib/docusign_templates/recipient.rb
+++ b/lib/docusign_templates/recipient.rb
@@ -1,8 +1,9 @@
 module DocusignTemplates
   class Recipient
-    attr_reader :data, :fields, :tabs
+    attr_reader :data, :template, :fields, :tabs
 
-    def initialize(data)
+    def initialize(data, template)
+      @template = template
       @data = data.except(:tabs, :pdf_fields).deep_dup
       @fields = parse_fields_or_tabs(data[:pdf_fields])
       @tabs = parse_fields_or_tabs(data[:tabs])
@@ -65,7 +66,7 @@ module DocusignTemplates
 
       fields_or_tabs.each do |type, type_fields|
         result[type] = type_fields.map do |field|
-          Field.new(field)
+          Field.new(field, template)
         end
       end
 

--- a/lib/docusign_templates/version.rb
+++ b/lib/docusign_templates/version.rb
@@ -1,3 +1,3 @@
 module DocusignTemplates
-  VERSION = "1.0.2"
+  VERSION = "2.0.0"
 end


### PR DESCRIPTION
- Fixes a GitHub security notification for `rake`
- Adds support for a `multipart` option, allowing uploading docs in binary format
  - Speeds up generation by reducing upload sizes by 1/4 compared to Base64
  - Speeds up generation by reducing the amount of JSON/Base64 parsing/encoding going on
- Kills the `async_as...` method
  - Performance impact was always minimal, any hit for killing it is made up for with faster uploads
  - Forking is always problematic