### PR TITLE
fix signature tab positioning on API 2.1 [FRONT-3507]

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: .
   specs:
-    docusign_templates (2.0.0)
+    docusign_templates (2.0.1)
       activesupport
       origami
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.3.1)
+    activesupport (6.0.3.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -16,18 +16,18 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     coderay (1.1.2)
     colorize (0.8.1)
-    concurrent-ruby (1.1.6)
+    concurrent-ruby (1.1.7)
     diff-lcs (1.3)
-    i18n (1.8.2)
+    i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     method_source (0.9.2)
-    minitest (5.14.1)
+    minitest (5.14.2)
     origami (2.1.0)
       colorize (~> 0.7)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    rake (12.3.3)
+    rake (13.0.3)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -44,17 +44,17 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
-    zeitwerk (2.3.0)
+    zeitwerk (2.4.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.17)
+  bundler
   docusign_templates!
   pry
-  rake (~> 12.3)
-  rspec (~> 3.0)
+  rake (~> 13.0)
+  rspec (~> 3.5)
 
 BUNDLED WITH
-   1.17.2
+   2.1.4

--- a/docusign_templates.gemspec
+++ b/docusign_templates.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport"
 
   spec.add_development_dependency "pry"
-  spec.add_development_dependency "bundler", "~> 1.17"
-  spec.add_development_dependency "rake", "~> 12.3"
-  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "rspec", "~> 3.5"
 end

--- a/lib/docusign_templates/field.rb
+++ b/lib/docusign_templates/field.rb
@@ -277,8 +277,6 @@ module DocusignTemplates
     def y_correction
       if is_pdf_field? || is_radio?
         1
-      elsif is_signature?
-        -21
       else
         0
       end

--- a/lib/docusign_templates/version.rb
+++ b/lib/docusign_templates/version.rb
@@ -1,3 +1,3 @@
 module DocusignTemplates
-  VERSION = "2.0.0"
+  VERSION = "2.0.1"
 end

--- a/spec/field_spec.rb
+++ b/spec/field_spec.rb
@@ -62,7 +62,7 @@ module DocusignTemplates
           field = Field.new(data, template)
 
           expect(field.x).to eq(x)
-          expect(field.y).to eq(y - 21)
+          expect(field.y).to eq(y)
         end
 
         it "does not offset other fields" do


### PR DESCRIPTION
- On DocuSign API 2.1, we no longer need to "correct" the position of the signature tabs from our templates. The "correction" now puts the tab in the wrong location.
- Other position corrections still seem necessary when comparing API 2.0 with 2.1